### PR TITLE
Python3 fixes

### DIFF
--- a/yas3fs/RecoverYas3fsPlugin.py
+++ b/yas3fs/RecoverYas3fsPlugin.py
@@ -150,14 +150,14 @@ class RecoverYas3fsPlugin(YAS3FSPlugin):
 							"etag_filename": etag_filename,
 							"etag": etag,
 							"exception": str(e),
-							"s3key" : dict(filter(self.s3key_json_filter, key.__dict__.iteritems()))
+							"s3key" : dict(filter(self.s3key_json_filter, iter(key.__dict__.items())))
 						}
 
 						self.logger.error("RecoverYAS3FS PLUGIN UPLOAD FAILED "  + json.dumps(json_recover))
 
 						self.make_recovery_copy(cache_file)
 
-					except Exception, e:
+					except Exception as e:
 						self.logger.exception(e)
 
 			return args[2] #????

--- a/yas3fs/__init__.py
+++ b/yas3fs/__init__.py
@@ -1962,7 +1962,7 @@ class YAS3FS(LoggingMixIn, Operations):
             key = self.get_key(path)
             number_of_buffers = 1 + int((key.size - 1 - starting_from) / self.buffer_size)
         else:
-            end_buffer = int(starting_from + length - 1) / self.buffer_size
+            end_buffer = int((starting_from + length - 1) / self.buffer_size)
             number_of_buffers = 1 + (end_buffer - start_buffer)
         for i in range(number_of_buffers):
             start = (start_buffer + i) * self.buffer_size

--- a/yas3fs/fuse.py
+++ b/yas3fs/fuse.py
@@ -438,6 +438,8 @@ class FUSE(object):
 
         # copies a string into the given buffer
         # (null terminated and truncated if necessary)
+        if not isinstance(ret, bytes):
+            ret = ret.encode('utf-8')
         data = create_string_buffer(ret[:bufsize - 1])
         memmove(buf, data, len(data))
         return 0
@@ -510,6 +512,8 @@ class FUSE(object):
         assert retsize <= size, \
             'actual amount read %d greater than expected %d' % (retsize, size)
 
+        if not isinstance(ret, bytes):
+            ret = ret.encode('utf-8')
         data = create_string_buffer(ret, retsize)
         memmove(buf, ret, retsize)
         return retsize
@@ -574,7 +578,8 @@ class FUSE(object):
 
         # do not truncate
         if retsize > size: return -ERANGE
-
+        if not isinstance(ret, bytes):
+            ret = ret.encode('utf-8')
         buf = create_string_buffer(ret, retsize)    # Does not add trailing 0
         memmove(value, buf, retsize)
 
@@ -590,7 +595,8 @@ class FUSE(object):
 
         # do not truncate
         if retsize > size: return -ERANGE
-
+        if not isinstance(ret, bytes):
+            ret = ret.encode('utf-8')
         buf = create_string_buffer(ret, retsize)
         memmove(namebuf, buf, retsize)
 


### PR DESCRIPTION
@pauricthelodger @mghughes Before I open the PR upstream, could you take a look at this and see if there's anything obvious that I should change?

Where logs log a Key object, python 3 raises an error if it is %s rather than %r
There are a couple of places where a loop through a dict's `.keys()` modified it in place - hence now wrapped in `list`

Mostly the rest are the usual python 3 sort of changes.